### PR TITLE
Ensure correct escaping of avatar URL, update tests

### DIFF
--- a/provider/custom_server.go
+++ b/provider/custom_server.go
@@ -165,7 +165,7 @@ func (c *CustomServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
 	user := token.User{
 		ID:      userID,
 		Name:    userID,
-		Picture: fmt.Sprintf(c.URL+"/avatar?user=%s", userID),
+		Picture: fmt.Sprintf(c.URL+"/avatar?user=%s", url.QueryEscape(userID)),
 	}
 	res, err := json.Marshal(user)
 	if err != nil {

--- a/provider/custom_server_test.go
+++ b/provider/custom_server_test.go
@@ -43,6 +43,9 @@ func TestCustomProvider(t *testing.T) {
 		L:       logger.Std,
 	}
 
+	var loginUsername string
+	var capturedUser token.User
+
 	sopts := CustomServerOpt{
 		URL:           "http://127.0.0.1:9096",
 		L:             logger.Std,
@@ -61,7 +64,7 @@ func TestCustomProvider(t *testing.T) {
 			jar.SetCookies(u, r.Cookies())
 
 			form := url.Values{}
-			form.Add("username", "admin")
+			form.Add("username", loginUsername)
 			form.Add("password", "pwd1234")
 
 			req, err := http.NewRequest("POST", "", strings.NewReader(form.Encode()))
@@ -87,9 +90,7 @@ func TestCustomProvider(t *testing.T) {
 			claims, err := params.JwtService.Parse(resp.Cookies()[0].Value)
 			assert.Nil(t, err)
 
-			assert.Equal(t, token.User{Name: "admin", ID: "admin",
-				Picture: "http://127.0.0.1:9096/avatar?user=admin", IP: ""}, *claims.User)
-
+			capturedUser = *claims.User
 		},
 	}
 
@@ -120,6 +121,7 @@ func TestCustomProvider(t *testing.T) {
 	client := &http.Client{Jar: jar, Timeout: time.Second * 10}
 
 	// check non-admin, permanent
+	loginUsername = "admin"
 	resp, err := client.Get("http://127.0.0.1:8080/auth/customprov/login?site=my-test-site")
 	require.Nil(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -127,6 +129,8 @@ func TestCustomProvider(t *testing.T) {
 	assert.Nil(t, err)
 	t.Logf("resp %s", string(body))
 	t.Logf("headers: %+v", resp.Header)
+	assert.Equal(t, token.User{Name: "admin", ID: "admin",
+		Picture: "http://127.0.0.1:9096/avatar?user=admin", IP: ""}, capturedUser)
 
 	// check avatar
 	resp, err = client.Get("http://127.0.0.1:9096/avatar?user=dev_user")
@@ -136,6 +140,18 @@ func TestCustomProvider(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 960, len(body))
 	t.Logf("headers: %+v", resp.Header)
+
+	// check malicious user ID
+	loginUsername = "attack"
+	resp, err = client.Get("http://127.0.0.1:8080/auth/customprov/login?site=my-test-site")
+	require.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	body, err = io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	t.Logf("resp %s", string(body))
+	t.Logf("headers: %+v", resp.Header)
+	// user ID in picture URL is encoded
+	assert.Equal(t, "http://127.0.0.1:9096/avatar?user=none%26attack%3Dvalue%22%3E%3Cscript%3Enasty+stuff%3C%2Fscript%3E", capturedUser.Picture)
 
 	// check default login page
 	prov.LoginPageHandler = nil
@@ -196,10 +212,13 @@ func initGoauth2Srv(t *testing.T) *goauth2.Server {
 		if r.ParseForm() != nil {
 			return "", fmt.Errorf("no username and password in request")
 		}
-		if r.Form.Get("username") != "admin" || r.Form.Get("password") != "pwd1234" {
-			return "", fmt.Errorf("wrong creds")
+		if r.Form.Get("username") == "admin" && r.Form.Get("password") == "pwd1234" {
+			return "admin", nil
 		}
-		return "admin", nil
+		if r.Form.Get("username") == "attack" && r.Form.Get("password") == "pwd1234" {
+			return "none&attack=value\"><script>nasty stuff</script>", nil
+		}
+		return "", fmt.Errorf("wrong creds")
 	})
 
 	srv.SetInternalErrorHandler(func(err error) (re *errors.Response) {

--- a/provider/verify.go
+++ b/provider/verify.go
@@ -176,10 +176,10 @@ func (e VerifyHandler) sendConfirmation(w http.ResponseWriter, r *http.Request) 
 		Token   string
 		Site    string
 	}{
-		User:    safeHTML(user),
-		Address: safeHTML(address),
-		Token:   template.HTMLEscapeString(tkn),
-		Site:    template.HTMLEscapeString(site),
+		User:    trim(user),
+		Address: trim(address),
+		Token:   tkn,
+		Site:    site,
 	}
 	buf := bytes.Buffer{}
 	if err = emailTmpl.Execute(&buf, tmplData); err != nil {
@@ -209,11 +209,8 @@ Confirmation for {{.User}} {{.Address}}, site {{.Site}}
 Token: {{.Token}}
 `
 
-func safeHTML(inp string) string {
-	res := template.HTMLEscapeString(inp)
-	res = strings.ReplaceAll(res, "&#34;", "\"")
-	res = strings.ReplaceAll(res, "&#39;", "'")
-	res = strings.ReplaceAll(res, "\n", "")
+func trim(inp string) string {
+	res := strings.ReplaceAll(inp, "\n", "")
 	res = strings.TrimSpace(res)
 	if len(res) > 128 {
 		return res[:128]

--- a/provider/verify_test.go
+++ b/provider/verify_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -59,7 +60,7 @@ func TestVerifyHandler_LoginSendConfirm(t *testing.T) {
 	assert.Equal(t, "test", e.Name())
 }
 
-func TestVerifyHandler_LoginSendConfirmRejected(t *testing.T) {
+func TestVerifyHandler_LoginSendConfirmEscapesBadInput(t *testing.T) {
 
 	emailer := mockSender{}
 	e := VerifyHandler{
@@ -77,20 +78,22 @@ func TestVerifyHandler_LoginSendConfirmRejected(t *testing.T) {
 
 	handler := http.HandlerFunc(e.LoginHandler)
 	rr := httptest.NewRecorder()
-	badUser := "%3C%21DOCTYPE%20html%3E%20%0A%3Chtml%3E%20%0A%3Chead%3E%0A%3Cmeta%20name%3D%22viewport%22%20content%3D%22width%3Ddevice-width%2C%20initial-scale%3D1%22%3E%0A%3Ctitle%3E%20Login%20Page%20%3C%2Ftitle%3E%0A%3Cstyle%3E%20%0ABody%20%7B%0A%20%20font-family%3A%20Calibri%2C%20Helvetica%2C%20sans-serif%3B%0A%20%20background-color%3A%20pink%3B%0A%7D%0Abutton%20%7B%20%0A%20%20%20%20%20%20%20background-color%3A%20%234CAF50%3B%20%0A%20%20%20%20%20%20%20width%3A%20100%25%3B%0A%20%20%20%20%20%20%20%20color%3A%20orange%3B%20%0A%20%20%20%20%20%20%20%20padding%3A%2015px%3B%20%0A%20%20%20%20%20%20%20%20margin%3A%2010px%200px%3B%20%0A%20%20%20%20%20%20%20%20border%3A%20none%3B%20%0A%20%20%20%20%20%20%20%20cursor%3A%20pointer%3B%20%0A%20%20%20%20%20%20%20%20%20%7D%20%0A%20form%20%7B%20%0A%20%20%20%20%20%20%20%20border%3A%203px%20solid%20%23f1f1f1%3B%20%0A%20%20%20%20%7D%20%0A%20input%5Btype%3Dtext%5D%2C%20input%5Btype%3Dpassword%5D%20%7B%20%0A%20%20%20%20%20%20%20%20width%3A%20100%25%3B%20%0A%20%20%20%20%20%20%20%20margin%3A%208px%200%3B%0A%20%20%20%20%20%20%20%20padding%3A%2012px%2020px%3B%20%0A%20%20%20%20%20%20%20%20display%3A%20inline-block%3B%20%0A%20%20%20%20%20%20%20%20border%3A%202px%20solid%20green%3B%20%0A%20%20%20%20%20%20%20%20box-sizing%3A%20border-box%3B%20%0A%20%20%20%20%7D%0A%20button%3Ahover%20%7B%20%0A%20%20%20%20%20%20%20%20opacity%3A%200.7%3B%20%0A%20%20%20%20%7D%20%0A%20%20.cancelbtn%20%7B%20%0A%20%20%20%20%20%20%20%20width%3A%20auto%3B%20%0A%20%20%20%20%20%20%20%20padding%3A%2010px%2018px%3B%0A%20%20%20%20%20%20%20%20margin%3A%2010px%205px%3B%0A%20%20%20%20%7D%20%0A%20%20%20%20%20%20%0A%20%20%20%0A%20.container%20%7B%20%0A%20%20%20%20%20%20%20%20padding%3A%2025px%3B%20%0A%20%20%20%20%20%20%20%20background-color%3A%20lightblue%3B%0A%20%20%20%20%7D%20%0A%3C%2Fstyle%3E%20%0A%3C%2Fhead%3E%20%20%0A%3Cbody%3E%20%20%0A%20%20%20%20%3Ccenter%3E%20%3Ch1%3E%20Student%20Login%20Form%20%3C%2Fh1%3E%20%3C%2Fcenter%3E%20%0A%20%20%20%20%3Cform%3E%0A%20%20%20%20%20%20%20%20%3Cdiv%20class%3D%22container%22%3E%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Clabel%3EUsername%20%3A%20%3C%2Flabel%3E%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cinput%20type%3D%22text%22%20placeholder%3D%22Enter%20Username%22%20name%3D%22username%22%20required%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Clabel%3EPassword%20%3A%20%3C%2Flabel%3E%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cinput%20type%3D%22password%22%20placeholder%3D%22Enter%20Password%22%20name%3D%22password%22%20required%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%20type%3D%22submit%22%3ELogin%3C%2Fbutton%3E%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cinput%20type%3D%22checkbox%22%20checked%3D%22checked%22%3E%20Remember%20me%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cbutton%20type%3D%22button%22%20class%3D%22cancelbtn%22%3E%20Cancel%3C%2Fbutton%3E%20%0A%20%20%20%20%20%20%20%20%20%20%20%20Forgot%20%3Ca%20href%3D%22%23%22%3E%20password%3F%20%3C%2Fa%3E%20%0A%20%20%20%20%20%20%20%20%3C%2Fdiv%3E%20%0A%20%20%20%20%3C%2Fform%3E%20%20%20%0A%3C%2Fbody%3E%20%20%20%0A%3C%2Fhtml%3E%0A%0A%20%0A"
-	req, err := http.NewRequest("GET", "/login?address=blah@user.com&user="+badUser+"&site=remark42", http.NoBody)
+	badData := "<html><script>nasty stuff</script>&lt;escaped&gt;</html>"
+	req, err := http.NewRequest("GET", "/login?address=blah@user.com&user="+url.QueryEscape(badData)+"&site="+url.QueryEscape(badData), http.NoBody)
 	require.NoError(t, err)
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, 200, rr.Code)
 	assert.Equal(t, "blah@user.com", emailer.to)
-	assert.Contains(t, emailer.text, "Password :    blah@user.com remark42 token:")
+	expectedEscaped := "&lt;html&gt;&lt;script&gt;nasty stuff&lt;/script&gt;&amp;lt;escaped&amp;gt;&lt;/html&gt;"
+	assert.Contains(t, emailer.text, expectedEscaped+" blah@user.com "+expectedEscaped+" token:")
 
 	tknStr := strings.Split(emailer.text, " token:")[1]
 	tkn, err := e.TokenService.Parse(tknStr)
 	assert.NoError(t, err)
 	t.Logf("%s %+v", tknStr, tkn)
-	assert.Equal(t, "&lt;h1&gt; Student Login Form &lt;/h1&gt;              &lt;div&gt;             Username :                          Password :   ::blah@user.com", tkn.Handshake.ID)
-	assert.Equal(t, "remark42", tkn.Audience)
+	// not escaped in these fields as they are not rendered as HTML
+	assert.Equal(t, badData+"::blah@user.com", tkn.Handshake.ID)
+	assert.Equal(t, badData, tkn.Audience)
 	assert.True(t, tkn.ExpiresAt > tkn.NotBefore)
 
 	assert.Equal(t, "test", e.Name())


### PR DESCRIPTION
Bring in improvements from https://github.com/go-pkgz/auth/pull/184

notably:
- avatar URLs are now correctly escaped if the user ID contains special characters such as `&`
- tests have been updated
- email fields are no-longer double-encoded